### PR TITLE
Improved service event logging

### DIFF
--- a/SyllabusPlusSchedulerService/ProjectInstaller.Designer.cs
+++ b/SyllabusPlusSchedulerService/ProjectInstaller.Designer.cs
@@ -39,7 +39,7 @@
             // 
             // PanoptoScheduleRecordingServiceInstaller
             // 
-            this.PanoptoScheduleRecordingServiceInstaller.Description = "Schedules Remote Recordering";
+            this.PanoptoScheduleRecordingServiceInstaller.Description = "Schedules Remote Recordings";
             this.PanoptoScheduleRecordingServiceInstaller.DisplayName = "Schedule Recording Service";
             this.PanoptoScheduleRecordingServiceInstaller.ServiceName = "Panopto Schedule Recording Service";
             // 


### PR DESCRIPTION
This commit adds logging to the scheduler. 

The scheduler now logs when the sync attempts to start, starts, and finishes to get an idea about what it's doing. For every session that needs to be synced, the scheduler will now also log the session's performed sync, and whether the sync succeeded or failed.

If the session sync succeeds, the error message is now set to null. Previously the error message would stay even if the session synced successfully.

Changed the service description from "Schedules Remote Recordering" to "Schedules Remote Recordings". 
