### PR TITLE
Updated version and adding hardening for possible infinite loop

### DIFF
--- a/SyllabusPlusSchedulerService/Properties/AssemblyInfo.cs
+++ b/SyllabusPlusSchedulerService/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/SyllabusPlusSchedulerService/SchedulerService.cs
+++ b/SyllabusPlusSchedulerService/SchedulerService.cs
@@ -98,16 +98,26 @@ namespace SyllabusPlusSchedulerService
                     using (SyllabusPlusDBContext db = new SyllabusPlusDBContext())
                     {
                         schedule =
-                            db.SchedulesTable.Select(s => s).
-                                Where(  s => (s.LastUpdate > s.LastPanoptoSync && s.PanoptoSyncSuccess == true)
-                                    ||  s.PanoptoSyncSuccess == null
-                                    || (s.PanoptoSyncSuccess == false && s.NumberOfAttempts < MAX_ATTEMPTS)).
-                                OrderBy(s => s.LastUpdate).FirstOrDefault();
+                            db.SchedulesTable.Select(s => s)
+                              .Where(  s => !s.LastPanoptoSync.HasValue
+                                         || (   s.LastUpdate > s.LastPanoptoSync.Value
+                                             && s.PanoptoSyncSuccess == true)
+                                         || s.PanoptoSyncSuccess == null
+                                         || (   s.PanoptoSyncSuccess == false
+                                             && s.NumberOfAttempts < MAX_ATTEMPTS))
+                              .OrderBy(s => s.LastUpdate).FirstOrDefault();
 
                         try
                         {
                             if (schedule != null)
                             {
+                                log.Debug(
+                                    String.Format("Attempting to sync a session. Name: {0}, Last update: {1}, Last Panopto sync: {2}, Panopto sync success: {3}, Number of attempts: {4}",
+                                                  schedule.SessionName,
+                                                  schedule.LastUpdate,
+                                                  (schedule.LastPanoptoSync != null) ? (DateTime?) schedule.LastPanoptoSync.Value : null,
+                                                  schedule.PanoptoSyncSuccess,
+                                                  schedule.NumberOfAttempts));
                                 if (!schedule.CancelSchedule.HasValue)
                                 {
                                     ScheduledRecordingResult result = null;
@@ -140,6 +150,12 @@ namespace SyllabusPlusSchedulerService
                                         schedule.ScheduledSessionId = result.SessionIDs.FirstOrDefault();
                                         schedule.NumberOfAttempts = 0;
                                         schedule.ErrorResponse = null;
+
+                                        if (schedule.LastUpdate > DateTime.UtcNow)
+                                        {
+                                            // In the rare case that the LastUpdateTime was in the future, set it to now, to ensure we don't repeat sync
+                                            schedule.LastUpdate = DateTime.UtcNow;
+                                        }
                                     }
                                     else
                                     {
@@ -175,14 +191,32 @@ namespace SyllabusPlusSchedulerService
                         }
                         catch (Exception ex)
                         {
-                            log.Error(ex.Message, ex);
+                            log.Error("Error syncing schedule " + ex.ToString(), ex);
                             schedule.ErrorResponse = ex.Message;
                             schedule.PanoptoSyncSuccess = false;
                             schedule.NumberOfAttempts++;
                         }
 
-                        // Save after every iteration to prevent scheduling not being insync with Panopto Server
-                        db.SaveChanges();
+                        try
+                        {
+                            if (schedule != null)
+                            {
+                                log.Debug(
+                                    String.Format("Attempting to save schedule back to database. Name: {0}, Last update: {1}, Last Panopto sync: {2}, Panopto sync success: {3}, Number of attempts: {4}",
+                                                  schedule.SessionName,
+                                                  schedule.LastUpdate,
+                                                  (schedule.LastPanoptoSync != null) ? (DateTime?)schedule.LastPanoptoSync.Value : null,
+                                                  schedule.PanoptoSyncSuccess,
+                                                  schedule.NumberOfAttempts));
+
+                                // Save after every iteration to prevent scheduling not being insync with Panopto Server
+                                db.SaveChanges();
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            log.Error("Error saving to database " + ex.ToString(), ex);
+                        }
                     }
                 } while (schedule != null);
             }

--- a/SyllabusPlusSchedulerServiceInstaller/Product.wxs
+++ b/SyllabusPlusSchedulerServiceInstaller/Product.wxs
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-	<Product Id="*" Name="Syllabus Plus Scheduler Service" Language="1033" Version="1.0.0.0" Manufacturer="Panopto" UpgradeCode="5b8ba71b-1624-4381-89dd-0c8644826326">
+	<Product Id="*" Name="Panopto Syllabus Plus Scheduler Service" Language="1033" Version="1.0.1.0" Manufacturer="Panopto" UpgradeCode="5b8ba71b-1624-4381-89dd-0c8644826326">
 		<Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
 
 		<MajorUpgrade DowngradeErrorMessage="A newer version of Syllabus Plus Scheduler Service is already installed." />
@@ -90,7 +90,7 @@
 					Vital="yes"
 					Name="Syllabus Plus Scheduler Service"
 					DisplayName="Panopto Syllabus Plus Scheduler Service"
-					Description="Schedules Remote Recordering"
+					Description="Schedules remote recordings"
 					Start="auto"
 					Account="LocalSystem"
 					ErrorControl="ignore"


### PR DESCRIPTION
If scheduled recording LastUpdate is in the future (say system time was
specified accidentally instead of UTC time or some other similar mistake
was made), the service could attempt to sync infinitely so this forces
an update to the LastUpdate time to avoid this case. Also rev'ed the
version in preparation for release and tweaked a few strings.
